### PR TITLE
Enable recursive parameter binding for control-flow blocks

### DIFF
--- a/crates/circuit/src/circuit_data.rs
+++ b/crates/circuit/src/circuit_data.rs
@@ -1578,13 +1578,15 @@ impl CircuitData {
             )));
         }
         let mut old_table = std::mem::take(&mut self.param_table);
-        self.assign_parameters_inner(
-            py,
-            slice
-                .iter()
-                .zip(old_table.drain_ordered())
-                .map(|(value, (param_ob, uses))| (param_ob, value.clone_ref(py), uses)),
-        )
+        let mut items = Vec::new();
+        let mut mapping = Vec::new();
+        for (value, (param_ob, uses)) in slice.iter().zip(old_table.drain_ordered()) {
+            let val = value.clone_ref(py);
+            mapping.push((param_ob.clone_ref(py), val.clone_ref(py)));
+            items.push((param_ob, val, uses));
+        }
+        self.assign_parameters_inner(py, items)?;
+        self.assign_parameters_blocks(py, &mapping)
     }
 
     /// Assigns parameters to circuit data based on a mapping of `ParameterUuid` : `Param`.
@@ -1596,21 +1598,21 @@ impl CircuitData {
         T: AsRef<Param>,
     {
         let mut items = Vec::new();
+        let mut mapping = Vec::new();
         for (param_uuid, value) in iter {
             // Assume all the Parameters are already in the circuit
             let param_obj = self.get_parameter_by_uuid(param_uuid);
             if let Some(param_obj) = param_obj {
                 // Copy or increase ref_count for Parameter, avoid acquiring the GIL.
-                items.push((
-                    param_obj.clone_ref(py),
-                    value.as_ref().clone_ref(py),
-                    self.param_table.pop(param_uuid)?,
-                ));
+                let val = value.as_ref().clone_ref(py);
+                mapping.push((param_obj.clone_ref(py), val.clone_ref(py)));
+                items.push((param_obj.clone_ref(py), val, self.param_table.pop(param_uuid)?));
             } else {
                 return Err(PyValueError::new_err("An invalid parameter was provided."));
             }
         }
-        self.assign_parameters_inner(py, items)
+        self.assign_parameters_inner(py, items)?;
+        self.assign_parameters_blocks(py, &mapping)
     }
 
     /// Returns an immutable view of the Interner used for Qargs
@@ -1947,6 +1949,37 @@ impl CircuitData {
         let new_index = self.data.len();
         self.data.push(packed);
         self.track_instruction_parameters(py, new_index)
+    }
+
+    /// Recursively assign parameters within any control-flow blocks contained in this circuit.
+    fn assign_parameters_blocks<'py>(&mut self, py: Python<'py>, mapping: &[(Py<PyAny>, Param)]) -> PyResult<()> {
+        if mapping.is_empty() {
+            return Ok(());
+        }
+        let assign_parameters_attr = intern!(py, "assign_parameters");
+        let kwargs = [
+            ("inplace", true),
+            ("flat_input", true),
+            ("strict", false),
+        ]
+        .into_py_dict(py)?;
+        let mapping_dict = mapping.into_py_dict(py)?;
+        for (index, inst) in self.data.iter_mut().enumerate() {
+            if !inst.op.control_flow() {
+                continue;
+            }
+            for param in inst.params_mut() {
+                if let Param::Obj(obj) = param {
+                    let obj = obj.bind_borrowed(py);
+                    if obj.is_instance(QUANTUM_CIRCUIT.get_bound(py))? {
+                        obj.call_method(assign_parameters_attr, (mapping_dict.clone_ref(py),), Some(kwargs))?;
+                    }
+                }
+            }
+            self.untrack_instruction_parameters(py, index)?;
+            self.track_instruction_parameters(py, index)?;
+        }
+        Ok(())
     }
 
     /// Add a param to the current global phase of the circuit

--- a/qiskit/circuit/quantumcircuit.py
+++ b/qiskit/circuit/quantumcircuit.py
@@ -4695,6 +4695,9 @@ class QuantumCircuit:
 
         The values can be assigned to the current circuit object or to a copy of it.
 
+        Parameter binding recurses into any control-flow operations in the circuit,
+        such as bodies of :class:`.ForLoopOp` or :class:`.IfElseOp` blocks.
+
         .. note::
             When ``parameters`` is given as a mapping, it is permissible to have keys that are
             strings of the parameter names; these will be looked up using :meth:`get_parameter`.

--- a/releasenotes/notes/control-flow-assign-recursive-ffccd5e5a8a3.yaml
+++ b/releasenotes/notes/control-flow-assign-recursive-ffccd5e5a8a3.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Parameter assignment now recurses into the bodies of control-flow operations
+    such as :class:`~.ForLoopOp` and :class:`~.IfElseOp`.  Parameters used only
+    inside these blocks can be bound directly from the parent circuit.

--- a/test/python/circuit/test_control_flow.py
+++ b/test/python/circuit/test_control_flow.py
@@ -1041,6 +1041,30 @@ class TestAddingControlFlowOperations(QiskitTestCase):
             expected.box(body.assign_parameters({x: math.pi}), [0], [])
             self.assertEqual(assigned, expected)
 
+    def test_nested_for_loop_parameter_assignment(self):
+        """Parameters inside nested for_loop blocks should be bound by the parent."""
+        x = Parameter("x")
+
+        inner = QuantumCircuit(1)
+        inner.rx(x, 0)
+
+        middle = QuantumCircuit(1)
+        middle.for_loop(range(2), None, inner.copy(), [0], [])
+
+        outer = QuantumCircuit(1)
+        outer.for_loop(range(3), None, middle.copy(), [0], [])
+
+        bound = outer.assign_parameters({x: math.pi})
+        self.assertEqual(set(bound.parameters), set())
+
+        expected_inner = inner.assign_parameters({x: math.pi})
+        expected_middle = QuantumCircuit(1)
+        expected_middle.for_loop(range(2), None, expected_inner, [0], [])
+        expected_outer = QuantumCircuit(1)
+        expected_outer.for_loop(range(3), None, expected_middle, [0], [])
+
+        self.assertEqual(bound, expected_outer)
+
     def test_can_add_op_with_captures_of_inputs(self):
         """Test circuit methods can capture input variables."""
         outer = QuantumCircuit(1, 1)


### PR DESCRIPTION
## Summary
- recursively bind parameters when assigning inside control-flow blocks
- add nested for-loop parameter binding test
- document that loops are supported when binding parameters
- release note for recursive parameter binding

## Testing
- `cargo test -p circuit --lib` *(fails: could not download Rust toolchain)*