### PR TITLE
Add RZZ option to Pauli feature map

### DIFF
--- a/crates/accelerate/src/circuit_library/pauli_feature_map.rs
+++ b/crates/accelerate/src/circuit_library/pauli_feature_map.rs
@@ -50,7 +50,7 @@ type Instruction = (
 /// Returns:
 ///     The ``CircuitData`` to construct the Pauli feature map.
 #[pyfunction]
-#[pyo3(signature = (feature_dimension, parameters, *, reps=1, entanglement=None, paulis=None, alpha=2.0, insert_barriers=false, data_map_func=None))]
+#[pyo3(signature = (feature_dimension, parameters, *, reps=1, entanglement=None, paulis=None, alpha=2.0, insert_barriers=false, phase_gate_for_paulis=true, data_map_func=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn pauli_feature_map(
     py: Python,
@@ -61,6 +61,7 @@ pub fn pauli_feature_map(
     paulis: Option<&Bound<PySequence>>,
     alpha: f64,
     insert_barriers: bool,
+    phase_gate_for_paulis: bool,
     data_map_func: Option<&Bound<PyAny>>,
 ) -> PyResult<CircuitData> {
     // normalize the Pauli strings
@@ -113,6 +114,7 @@ pub fn pauli_feature_map(
             &pauli_strings,
             entanglement,
             data_map_func,
+            phase_gate_for_paulis,
         )?;
         packed_insts.extend(evo_layer);
 
@@ -152,6 +154,7 @@ fn _get_evolution_layer<'a>(
     pauli_strings: &'a [String],
     entanglement: &'a Bound<PyAny>,
     data_map_func: Option<&'a Bound<PyAny>>,
+    phase_gate_for_paulis: bool,
 ) -> PyResult<Vec<Instruction>> {
     let mut insts: Vec<Instruction> = Vec::new();
 
@@ -182,7 +185,7 @@ fn _get_evolution_layer<'a>(
                 pauli,
                 indices.into_iter().rev().collect(),
                 multiply_param(&angle, alpha, py),
-                true,
+                phase_gate_for_paulis,
                 false,
             );
             insts.extend(evo);

--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -29,7 +29,7 @@ from ..n_local.n_local import NLocal
 
 
 def _normalize_entanglement(
-    entanglement: str | Mapping[int, Sequence[Sequence[int]]]
+    entanglement: str | Mapping[int, Sequence[Sequence[int]]],
 ) -> str | dict[int, list[tuple[int]]]:
     if isinstance(entanglement, str):
         return entanglement
@@ -53,6 +53,7 @@ def pauli_feature_map(
     data_map_func: Callable[[Parameter], ParameterExpression] | None = None,
     parameter_prefix: str = "x",
     insert_barriers: bool = False,
+    use_phase: bool = True,
     name: str = "PauliFeatureMap",
 ) -> QuantumCircuit:
     r"""The Pauli expansion circuit.
@@ -98,6 +99,11 @@ def pauli_feature_map(
 
     Please refer to :func:`.z_feature_map` for the case of single-qubit Pauli-:math:`Z` rotations
     and to :func:`.zz_feature_map` for the single- and two-qubit Pauli-:math:`Z` rotations.
+
+    The ``use_phase`` option controls how two-qubit Pauli evolutions are
+    synthesized. If ``True`` (the default) the evolution is implemented using
+    CX gates and phase rotations, otherwise native two-qubit rotations such as
+    ``RZZ`` are used where available.
 
     Examples:
 
@@ -160,6 +166,7 @@ def pauli_feature_map(
             data_map_func=data_map_func,
             alpha=alpha,
             insert_barriers=insert_barriers,
+            phase_gate_for_paulis=use_phase,
         ),
         name=name,
     )
@@ -242,6 +249,7 @@ def z_feature_map(
         data_map_func=data_map_func,
         parameter_prefix=parameter_prefix,
         insert_barriers=insert_barriers,
+        phase_gate_for_paulis=not use_rzz,
         name=name,
     )
 
@@ -256,6 +264,7 @@ def zz_feature_map(
     data_map_func: Callable[[Parameter], ParameterExpression] | None = None,
     parameter_prefix: str = "x",
     insert_barriers: bool = False,
+    use_rzz: bool = False,
     name: str = "ZZFeatureMap",
 ) -> QuantumCircuit:
     r"""Second-order Pauli-Z evolution circuit.
@@ -274,6 +283,10 @@ def zz_feature_map(
 
     where :math:`\varphi` is a classical non-linear function, which defaults to :math:`\varphi(x) = x`
     if and :math:`\varphi(x,y) = (\pi - x)(\pi - y)`.
+
+    The ``use_rzz`` option exposes the underlying two-qubit rotation gate. When
+    set to ``True`` the evolution is synthesized with :class:`~qiskit.circuit.library.RZZGate`
+    instead of CX and phase rotations.
 
     Examples:
 

--- a/test/python/circuit/library/test_pauli_feature_map.py
+++ b/test/python/circuit/library/test_pauli_feature_map.py
@@ -587,6 +587,14 @@ class TestPauliFeatureMap(QiskitTestCase):
 
         self.assertEqual(ref, encoding)
 
+    def test_use_rzz_gate(self):
+        """RZZ gates are used when requested."""
+
+        circuit = zz_feature_map(2, reps=1, use_rzz=True)
+        ops = circuit.count_ops()
+        self.assertIn("rzz", ops)
+        self.assertNotIn("cx", ops)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- expose `use_phase` argument in `pauli_feature_map` to select synthesis style
- plumb the option through Rust implementation
- update `zz_feature_map` with `use_rzz` convenience flag
- test that `use_rzz` produces RZZ gates

## Testing
- `pytest test/python/circuit/library/test_pauli_feature_map.py::TestPauliFeatureMap::test_use_rzz_gate` *(fails: ImportError: cannot import name '_accelerate')*