### PR TITLE
Fix parameter name in z_feature_map

### DIFF
--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -249,7 +249,7 @@ def z_feature_map(
         data_map_func=data_map_func,
         parameter_prefix=parameter_prefix,
         insert_barriers=insert_barriers,
-        phase_gate_for_paulis=not use_rzz,
+        use_phase=not use_rzz,
         name=name,
     )
 


### PR DESCRIPTION
## Summary
- fix incorrect parameter name passed to `pauli_feature_map`

## Testing
- `make lint-incr` *(fails: ModuleNotFoundError: No module named 'pylint')*
- `pytest -k pauli_feature_map -q` *(fails: ModuleNotFoundError: No module named 'ddt')*