### PR TITLE
Deprecate legacy circuit builders

### DIFF
--- a/qiskit/circuit/library/arithmetic/exact_reciprocal.py
+++ b/qiskit/circuit/library/arithmetic/exact_reciprocal.py
@@ -15,6 +15,7 @@ from math import isclose
 import numpy as np
 from qiskit.circuit import QuantumCircuit, QuantumRegister, Gate
 from qiskit.circuit.library.generalized_gates import UCRYGate
+from qiskit.utils.deprecation import deprecate_func
 
 
 class ExactReciprocal(QuantumCircuit):
@@ -25,6 +26,11 @@ class ExactReciprocal(QuantumCircuit):
         |x\rangle |0\rangle \mapsto \cos(1/x)|x\rangle|0\rangle + \sin(1/x)|x\rangle |1\rangle
     """
 
+    @deprecate_func(
+        since="2.2",
+        additional_msg="Use qiskit.circuit.library.ExactReciprocalGate instead.",
+        pending=True,
+    )
     def __init__(
         self, num_state_qubits: int, scaling: float, neg_vals: bool = False, name: str = "1/x"
     ) -> None:

--- a/qiskit/circuit/library/arithmetic/linear_amplitude_function.py
+++ b/qiskit/circuit/library/arithmetic/linear_amplitude_function.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 import numpy as np
 from qiskit.circuit import QuantumCircuit, Gate
+from qiskit.utils.deprecation import deprecate_func
 
 from .piecewise_linear_pauli_rotations import (
     PiecewiseLinearPauliRotations,
@@ -77,6 +78,11 @@ class LinearAmplitudeFunction(QuantumCircuit):
              `arXiv:2005.10780 <http://arxiv.org/abs/2005.10780>`_
     """
 
+    @deprecate_func(
+        since="2.2",
+        additional_msg="Use qiskit.circuit.library.LinearAmplitudeFunctionGate instead.",
+        pending=True,
+    )
     def __init__(
         self,
         num_state_qubits: int,

--- a/qiskit/circuit/library/arithmetic/piecewise_polynomial_pauli_rotations.py
+++ b/qiskit/circuit/library/arithmetic/piecewise_polynomial_pauli_rotations.py
@@ -54,10 +54,13 @@ class PiecewisePolynomialPauliRotations(FunctionalPauliRotations):
     Examples:
         >>> from qiskit import QuantumCircuit
         >>> from qiskit.circuit.library.arithmetic.piecewise_polynomial_pauli_rotations import\
-        ... PiecewisePolynomialPauliRotations
-        >>> qubits, breakpoints, coeffs = (2, [0, 2], [[0, -1.2],[-1, 1, 3]])
-        >>> poly_r = PiecewisePolynomialPauliRotations(num_state_qubits=qubits,
-        ...breakpoints=breakpoints, coeffs=coeffs)
+        ... PiecewisePolynomialPauliRotationsGate
+        >>> qubits, breakpoints, coeffs = (2, [0, 2], [[0, -1.2], [-1, 1, 3]])
+        >>> poly_r = PiecewisePolynomialPauliRotationsGate(
+        ...     num_state_qubits=qubits,
+        ...     breakpoints=breakpoints,
+        ...     coeffs=coeffs,
+        ... )
         >>>
         >>> qc = QuantumCircuit(poly_r.num_qubits)
         >>> qc.h(list(range(qubits)));
@@ -338,10 +341,13 @@ class PiecewisePolynomialPauliRotationsGate(Gate):
     Examples:
         >>> from qiskit import QuantumCircuit
         >>> from qiskit.circuit.library.arithmetic.piecewise_polynomial_pauli_rotations import\
-        ... PiecewisePolynomialPauliRotations
-        >>> qubits, breakpoints, coeffs = (2, [0, 2], [[0, -1.2],[-1, 1, 3]])
-        >>> poly_r = PiecewisePolynomialPauliRotations(num_state_qubits=qubits,
-        ...breakpoints=breakpoints, coeffs=coeffs)
+        ... PiecewisePolynomialPauliRotationsGate
+        >>> qubits, breakpoints, coeffs = (2, [0, 2], [[0, -1.2], [-1, 1, 3]])
+        >>> poly_r = PiecewisePolynomialPauliRotationsGate(
+        ...     num_state_qubits=qubits,
+        ...     breakpoints=breakpoints,
+        ...     coeffs=coeffs,
+        ... )
         >>>
         >>> qc = QuantumCircuit(poly_r.num_qubits)
         >>> qc.h(list(range(qubits)));

--- a/qiskit/circuit/library/data_preparation/pauli_feature_map.py
+++ b/qiskit/circuit/library/data_preparation/pauli_feature_map.py
@@ -277,7 +277,7 @@ def zz_feature_map(
 
     Examples:
 
-        >>> from qiskit.circuit.library import ZZFeatureMap
+        >>> from qiskit.circuit.library import zz_feature_map
         >>> prep = zz_feature_map(2, reps=1)
         >>> print(prep)
              ┌───┐┌─────────────┐
@@ -363,8 +363,8 @@ class PauliFeatureMap(NLocal):
 
     The circuit contains ``reps`` repetitions of this transformation.
 
-    Please refer to :class:`.ZFeatureMap` for the case of single-qubit Pauli-:math:`Z` rotations
-    and to :class:`.ZZFeatureMap` for the single- and two-qubit Pauli-:math:`Z` rotations.
+    Please refer to :func:`.z_feature_map` for the case of single-qubit Pauli-:math:`Z` rotations
+    and to :func:`.zz_feature_map` for the single- and two-qubit Pauli-:math:`Z` rotations.
 
     Examples:
 

--- a/qiskit/circuit/library/phase_oracle.py
+++ b/qiskit/circuit/library/phase_oracle.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from qiskit.circuit import QuantumCircuit, Gate
+from qiskit.utils.deprecation import deprecate_func
 
 from qiskit.synthesis.boolean.boolean_expression import BooleanExpression
 
@@ -49,6 +50,11 @@ class PhaseOracle(QuantumCircuit):
     default synthesizer.
     """
 
+    @deprecate_func(
+        since="2.2",
+        additional_msg="Use qiskit.circuit.library.PhaseOracleGate instead.",
+        pending=True,
+    )
     def __init__(
         self,
         expression: str,

--- a/qiskit/circuit/library/quantum_volume.py
+++ b/qiskit/circuit/library/quantum_volume.py
@@ -18,6 +18,7 @@ from typing import Optional, Union
 
 import numpy as np
 from qiskit.circuit import QuantumCircuit, CircuitInstruction
+from qiskit.utils.deprecation import deprecate_func
 from qiskit.circuit.library.generalized_gates import PermutationGate, UnitaryGate
 from qiskit._accelerate.circuit_library import quantum_volume as qv_rs
 
@@ -58,6 +59,11 @@ class QuantumVolume(QuantumCircuit):
     [`arXiv:1811.12926 <https://arxiv.org/abs/1811.12926>`_]
     """
 
+    @deprecate_func(
+        since="2.2",
+        additional_msg="Use qiskit.circuit.library.quantum_volume instead.",
+        pending=True,
+    )
     def __init__(
         self,
         num_qubits: int,

--- a/releasenotes/notes/2.2/deprecate-circuit-lib-gates-14478.yaml
+++ b/releasenotes/notes/2.2/deprecate-circuit-lib-gates-14478.yaml
@@ -1,0 +1,11 @@
+---
+deprecations:
+  - |
+    The quantum circuit classes :class:`~qiskit.circuit.library.ExactReciprocal`,
+    :class:`~qiskit.circuit.library.LinearAmplitudeFunction`,
+    :class:`~qiskit.circuit.library.QuantumVolume`, and
+    :class:`~qiskit.circuit.library.PhaseOracle` are deprecated.
+    Use :class:`~qiskit.circuit.library.ExactReciprocalGate`,
+    :class:`~qiskit.circuit.library.LinearAmplitudeFunctionGate`,
+    the :func:`~qiskit.circuit.library.quantum_volume` function,
+    and :class:`~qiskit.circuit.library.PhaseOracleGate` instead.

--- a/test/python/circuit/library/test_linear_amplitude_function.py
+++ b/test/python/circuit/library/test_linear_amplitude_function.py
@@ -108,15 +108,10 @@ class TestLinearAmplitudeFunctional(QiskitTestCase):
             breakpoints=breakpoints,
         )
 
-        for use_gate in [True, False]:
-            constructor = LinearAmplitudeFunctionGate if use_gate else LinearAmplitudeFunction
-            num_ancillas = int(len(breakpoints or [0]) > 1) if use_gate else None
-
-            with self.subTest(use_gate=use_gate):
-                linear_f = constructor(
-                    num_state_qubits, slope, offset, domain, image, rescaling_factor, breakpoints
-                )
-                self.assertFunctionIsCorrect(linear_f, reference, num_ancillas)
+        linear_f = LinearAmplitudeFunctionGate(
+            num_state_qubits, slope, offset, domain, image, rescaling_factor, breakpoints
+        )
+        self.assertFunctionIsCorrect(linear_f, reference, int(len(breakpoints or [0]) > 1))
 
     def test_not_including_start_in_breakpoints(self):
         """Test not including the start of the domain works."""
@@ -139,7 +134,7 @@ class TestLinearAmplitudeFunctional(QiskitTestCase):
             breakpoints=breakpoints,
         )
 
-        linear_f = LinearAmplitudeFunction(
+        linear_f = LinearAmplitudeFunctionGate(
             num_state_qubits, slope, offset, domain, image, rescaling_factor, breakpoints
         )
 
@@ -158,31 +153,31 @@ class TestLinearAmplitudeFunctional(QiskitTestCase):
 
         with self.subTest("mismatching breakpoints size"):
             with self.assertRaises(ValueError):
-                _ = LinearAmplitudeFunction(
+                _ = LinearAmplitudeFunctionGate(
                     num_state_qubits, slope, offset, domain, image, rescaling_factor, [0]
                 )
 
         with self.subTest("mismatching offsets"):
             with self.assertRaises(ValueError):
-                _ = LinearAmplitudeFunction(
+                _ = LinearAmplitudeFunctionGate(
                     num_state_qubits, slope, [0], domain, image, rescaling_factor, breakpoints
                 )
 
         with self.subTest("mismatching slopes"):
             with self.assertRaises(ValueError):
-                _ = LinearAmplitudeFunction(
+                _ = LinearAmplitudeFunctionGate(
                     num_state_qubits, [0], offset, domain, image, rescaling_factor, breakpoints
                 )
 
         with self.subTest("breakpoints outside of domain"):
             with self.assertRaises(ValueError):
-                _ = LinearAmplitudeFunction(
+                _ = LinearAmplitudeFunctionGate(
                     num_state_qubits, slope, offset, (0, 0.2), image, rescaling_factor, breakpoints
                 )
 
         with self.subTest("breakpoints not sorted"):
             with self.assertRaises(ValueError):
-                _ = LinearAmplitudeFunction(
+                _ = LinearAmplitudeFunctionGate(
                     num_state_qubits, slope, offset, domain, image, rescaling_factor, [1, 0]
                 )
 
@@ -195,7 +190,7 @@ class TestLinearAmplitudeFunctional(QiskitTestCase):
         image = (-2, 0)
         rescaling_factor = 0.1
 
-        circuit = LinearAmplitudeFunction(
+        circuit = LinearAmplitudeFunctionGate(
             num_state_qubits, slope, offset, domain, image, rescaling_factor
         )
 

--- a/test/python/circuit/library/test_phase_and_bitflip_oracles.py
+++ b/test/python/circuit/library/test_phase_and_bitflip_oracles.py
@@ -35,7 +35,7 @@ class TestPhaseOracleAndGate(QiskitTestCase):
     @unpack
     def test_evaluate_bitstring(self, expression, input_bitstring, expected):
         """PhaseOracle(...).evaluate_bitstring"""
-        oracle = PhaseOracle(expression)
+        oracle = PhaseOracleGate(expression)
         result = oracle.evaluate_bitstring(input_bitstring)
         self.assertEqual(result, expected)
 
@@ -50,13 +50,12 @@ class TestPhaseOracleAndGate(QiskitTestCase):
     @unpack
     def test_statevector(self, expression, truth_table):
         """Circuit generation"""
-        for use_gate in [True, False]:
-            oracle = PhaseOracleGate(expression) if use_gate else PhaseOracle(expression)
-            num_qubits = oracle.num_qubits
-            circuit = QuantumCircuit(num_qubits)
-            circuit.h(range(num_qubits))
-            circuit.compose(oracle, inplace=True)
-            statevector = Statevector.from_instruction(circuit)
+        oracle = PhaseOracleGate(expression)
+        num_qubits = oracle.num_qubits
+        circuit = QuantumCircuit(num_qubits)
+        circuit.h(range(num_qubits))
+        circuit.compose(oracle, inplace=True)
+        statevector = Statevector.from_instruction(circuit)
 
             valid_state = -1 / sqrt(2**num_qubits)
             invalid_state = 1 / sqrt(2**num_qubits)
@@ -68,9 +67,8 @@ class TestPhaseOracleAndGate(QiskitTestCase):
 
             expected_invalid = [state not in good_states for state in states]
             result_invalid = [isclose(statevector.data[state], invalid_state) for state in states]
-            with self.subTest(use_gate=use_gate):
-                self.assertListEqual(expected_valid, result_valid)
-                self.assertListEqual(expected_invalid, result_invalid)
+        self.assertListEqual(expected_valid, result_valid)
+        self.assertListEqual(expected_invalid, result_invalid)
 
     @data(
         ("((A & C) | (B & D)) & ~(C & D)", None, [3, 7, 12, 13]),
@@ -79,17 +77,12 @@ class TestPhaseOracleAndGate(QiskitTestCase):
     @unpack
     def test_variable_order(self, expression, var_order, good_states):
         """Circuit generation"""
-        for use_gate in [True, False]:
-            oracle = (
-                PhaseOracleGate(expression, var_order=var_order)
-                if use_gate
-                else PhaseOracle(expression, var_order=var_order)
-            )
-            num_qubits = oracle.num_qubits
-            circuit = QuantumCircuit(num_qubits)
-            circuit.h(range(num_qubits))
-            circuit.compose(oracle, inplace=True)
-            statevector = Statevector.from_instruction(circuit)
+        oracle = PhaseOracleGate(expression, var_order=var_order)
+        num_qubits = oracle.num_qubits
+        circuit = QuantumCircuit(num_qubits)
+        circuit.h(range(num_qubits))
+        circuit.compose(oracle, inplace=True)
+        statevector = Statevector.from_instruction(circuit)
 
             valid_state = -1 / sqrt(2**num_qubits)
             invalid_state = 1 / sqrt(2**num_qubits)
@@ -100,9 +93,8 @@ class TestPhaseOracleAndGate(QiskitTestCase):
 
             expected_invalid = [state not in good_states for state in states]
             result_invalid = [isclose(statevector.data[state], invalid_state) for state in states]
-            with self.subTest(use_gate=use_gate):
-                self.assertListEqual(expected_valid, result_valid)
-                self.assertListEqual(expected_invalid, result_invalid)
+        self.assertListEqual(expected_valid, result_valid)
+        self.assertListEqual(expected_invalid, result_invalid)
 
 
 @ddt

--- a/test/python/circuit/library/test_quantum_volume.py
+++ b/test/python/circuit/library/test_quantum_volume.py
@@ -15,7 +15,6 @@
 import unittest
 
 from test.utils.base import QiskitTestCase
-from qiskit.circuit.library import QuantumVolume
 from qiskit.circuit.library.quantum_volume import quantum_volume
 
 
@@ -24,16 +23,16 @@ class TestQuantumVolumeLibrary(QiskitTestCase):
 
     def test_qv_seed_reproducibility(self):
         """Test qv circuit."""
-        left = QuantumVolume(4, 4, seed=28, classical_permutation=False)
-        right = QuantumVolume(4, 4, seed=28, classical_permutation=False)
+        left = quantum_volume(4, 4, seed=28)
+        right = quantum_volume(4, 4, seed=28)
         self.assertEqual(left, right)
 
-        left = QuantumVolume(4, 4, seed=3, classical_permutation=True)
-        right = QuantumVolume(4, 4, seed=3, classical_permutation=True)
+        left = quantum_volume(4, 4, seed=3)
+        right = quantum_volume(4, 4, seed=3)
         self.assertEqual(left, right)
 
-        left = QuantumVolume(4, 4, seed=2024, flatten=True)
-        right = QuantumVolume(4, 4, seed=2024, flatten=True)
+        left = quantum_volume(4, 4, seed=2024)
+        right = quantum_volume(4, 4, seed=2024)
         self.assertEqual(left, right)
 
     def test_qv_function_seed_reproducibility(self):


### PR DESCRIPTION
## Summary
- deprecate legacy circuit classes ExactReciprocal, LinearAmplitudeFunction, QuantumVolume and PhaseOracle
- update docs of piecewise polynomial and feature map helpers
- switch tests to gate/function versions
- add release note

## Testing
- `pytest -k "linear_amplitude_function or phase_and_bitflip_oracles or quantum_volume" -q` *(fails: ImportError: cannot import name '_accelerate')*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecation**
  - Marked the following classes as deprecated: `ExactReciprocal`, `LinearAmplitudeFunction`, `QuantumVolume`, and `PhaseOracle`. Users are advised to use their respective gate classes or functions instead.
- **Documentation**
  - Updated docstring examples and references to guide users toward the new gate classes and functions.
- **Tests**
  - Updated tests to use only the new gate classes and functions, removing usage of deprecated classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->