### PR TITLE
Add syllable tree utility and CLI

### DIFF
--- a/qiskit/utils/__init__.py
+++ b/qiskit/utils/__init__.py
@@ -53,6 +53,16 @@ Optional Dependency Checkers
 ============================
 
 .. automodule:: qiskit.utils.optionals
+
+Syllable tree helper
+====================
+
+.. autoclass:: SyllableTree
+    :members: render, to_dict, to_json
+
+.. autofunction:: build_syllable_tree
+.. autofunction:: run_syllable_tree_app
+.. autofunction:: syllabify
 """
 
 from .deprecation import (
@@ -63,6 +73,15 @@ from .deprecation import (
 from .units import apply_prefix, detach_prefix
 from .classtools import wrap_method
 from .lazy_tester import LazyDependencyManager, LazyImportTester, LazySubprocessTester
+from .syllable_tree import (
+    SyllableTree,
+    TreeNode,
+    build_syllable_tree,
+    parse_syllable_hint,
+    run_syllable_tree_app,
+    split_onset_nucleus_coda,
+    syllabify,
+)
 
 from . import optionals
 
@@ -78,13 +97,20 @@ __all__ = [
     "LazyDependencyManager",
     "LazyImportTester",
     "LazySubprocessTester",
+    "SyllableTree",
+    "TreeNode",
     "add_deprecation_to_docstring",
     "apply_prefix",
+    "build_syllable_tree",
     "default_num_processes",
     "deprecate_arg",
     "deprecate_func",
     "is_main_process",
     "local_hardware_info",
     "parallel_map",
+    "parse_syllable_hint",
+    "run_syllable_tree_app",
     "should_run_in_parallel",
+    "split_onset_nucleus_coda",
+    "syllabify",
 ]

--- a/qiskit/utils/syllable_tree.py
+++ b/qiskit/utils/syllable_tree.py
@@ -1,0 +1,334 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Utilities for building a simple syllable tree.
+
+The :class:`~qiskit.utils.syllable_tree.SyllableTree` class builds a light-weight
+hierarchical representation of the syllables that make up a word.  It follows a
+basic linguistic decomposition into onset, nucleus and coda and offers helpers
+to render the structure as ASCII art or JSON data.  The module also exposes a
+small command line interface that can be invoked with::
+
+    python -m qiskit.utils.syllable_tree VOORBEELDWOORD
+
+The heuristics in this module are intentionally conservative: they aim to
+generate readable trees for Dutch- and English-like words without pretending to
+be a complete syllabification engine.  Users can provide manual syllable hints
+when the automated guess is insufficient.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import argparse
+import json
+import re
+import sys
+from typing import Iterator, List, Sequence
+
+_VOWELS = set("aeiouyáéíóúàèìòùäëïöüâêîôû")
+_ONSET_CLUSTERS = {
+    "sch",
+    "scr",
+    "spl",
+    "spr",
+    "str",
+    "thr",
+    "chr",
+    "phr",
+    "shr",
+    "squ",
+    "br",
+    "cr",
+    "dr",
+    "fr",
+    "gr",
+    "pr",
+    "tr",
+    "vr",
+    "kr",
+    "bl",
+    "cl",
+    "fl",
+    "gl",
+    "pl",
+    "sl",
+    "sk",
+    "sm",
+    "sn",
+    "sp",
+    "st",
+    "sw",
+    "dw",
+    "tw",
+    "ch",
+    "gh",
+    "ph",
+    "rh",
+    "sh",
+    "th",
+    "wh",
+    "gn",
+    "kn",
+    "qu",
+}
+_SPLIT_HINT = re.compile(r"[-\s]+")
+
+
+@dataclass
+class TreeNode:
+    """A node within a syllable tree."""
+
+    label: str
+    children: List["TreeNode"] = field(default_factory=list)
+
+    def add_child(self, node: "TreeNode") -> "TreeNode":
+        """Attach *node* as a child and return it."""
+
+        self.children.append(node)
+        return node
+
+    def render(self) -> str:
+        """Render the tree as ASCII art."""
+
+        lines: List[str] = []
+
+        def _render(current: "TreeNode", prefix: str, is_last: bool) -> None:
+            connector = "" if not prefix else ("└── " if is_last else "├── ")
+            lines.append(f"{prefix}{connector}{current.label}")
+            next_prefix = prefix + ("    " if is_last else "│   ")
+            for index, child in enumerate(current.children):
+                _render(child, next_prefix, index == len(current.children) - 1)
+
+        _render(self, "", True)
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict:
+        """Convert the node to a JSON-serialisable dictionary."""
+
+        return {
+            "label": self.label,
+            "children": [child.to_dict() for child in self.children],
+        }
+
+
+@dataclass
+class SyllableTree:
+    """Representation of the syllable structure of a word."""
+
+    word: str
+    syllables: List[str]
+    root: TreeNode
+
+    @classmethod
+    def from_word(
+        cls, word: str, syllable_hint: Sequence[str] | None = None
+    ) -> "SyllableTree":
+        """Construct a tree for *word*.
+
+        Args:
+            word: Input word that will be analysed.
+            syllable_hint: Optional manual syllable split.  When omitted a
+                simple heuristic is used to guess the syllables.
+        """
+
+        syllables = list(syllable_hint) if syllable_hint else syllabify(word)
+        root = TreeNode(f"Word: {word}")
+        for index, syllable in enumerate(syllables, start=1):
+            branch = TreeNode(f"Syllable {index}: {syllable}")
+            onset, nucleus, coda = split_onset_nucleus_coda(syllable)
+            if onset:
+                onset_node = branch.add_child(TreeNode("Onset"))
+                for char in onset:
+                    onset_node.add_child(TreeNode(char))
+            rime = TreeNode("Rime")
+            if nucleus:
+                nucleus_node = rime.add_child(TreeNode("Nucleus"))
+                nucleus_node.add_child(TreeNode(nucleus))
+            if coda:
+                coda_node = rime.add_child(TreeNode("Coda"))
+                for char in coda:
+                    coda_node.add_child(TreeNode(char))
+            if rime.children:
+                branch.add_child(rime)
+            if not branch.children:
+                for char in syllable:
+                    branch.add_child(TreeNode(char))
+            root.add_child(branch)
+        return cls(word=word, syllables=syllables, root=root)
+
+    def render(self) -> str:
+        """Render the tree as ASCII art."""
+
+        return self.root.render()
+
+    def to_dict(self) -> dict:
+        """Convert the tree to a dictionary."""
+
+        return {
+            "word": self.word,
+            "syllables": list(self.syllables),
+            "tree": self.root.to_dict(),
+        }
+
+    def to_json(self, *, indent: int = 2) -> str:
+        """Return a JSON dump of the tree."""
+
+        return json.dumps(self.to_dict(), ensure_ascii=False, indent=indent)
+
+    def __str__(self) -> str:
+        return self.render()
+
+
+def syllabify(word: str) -> List[str]:
+    """Split *word* into syllables using a light-weight heuristic."""
+
+    word = word.strip()
+    if not word:
+        return []
+    parts = [part for part in _SPLIT_HINT.split(word) if part]
+    if not parts:
+        return [word]
+    syllables: List[str] = []
+    for part in parts:
+        syllables.extend(_syllabify_segment(part))
+    return syllables or [word]
+
+
+def build_syllable_tree(
+    word: str, syllable_hint: Sequence[str] | None = None
+) -> SyllableTree:
+    """Convenience wrapper around :meth:`SyllableTree.from_word`."""
+
+    return SyllableTree.from_word(word, syllable_hint=syllable_hint)
+
+
+def parse_syllable_hint(hint: str) -> List[str]:
+    """Parse a manually provided syllable hint string."""
+
+    return [part for part in _SPLIT_HINT.split(hint) if part]
+
+
+def split_onset_nucleus_coda(syllable: str) -> tuple[str, str, str]:
+    """Split *syllable* into onset, nucleus and coda components."""
+
+    if not syllable:
+        return "", "", ""
+    lower = syllable.lower()
+    try:
+        first_vowel = next(index for index, char in enumerate(lower) if char in _VOWELS)
+    except StopIteration:
+        return syllable, "", ""
+    onset = syllable[:first_vowel]
+    nucleus_end = first_vowel
+    while nucleus_end < len(syllable) and lower[nucleus_end] in _VOWELS:
+        nucleus_end += 1
+    nucleus = syllable[first_vowel:nucleus_end]
+    coda = syllable[nucleus_end:]
+    return onset, nucleus, coda
+
+
+def run_syllable_tree_app(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the small syllable-tree command line utility."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("word", nargs="?", help="Woord of zin om te analyseren.")
+    parser.add_argument(
+        "-s",
+        "--syllables",
+        help="Handmatige lettergreep verdeling, gescheiden door '-' of spaties.",
+    )
+    parser.add_argument("--json", action="store_true", help="Geef de boom als JSON terug.")
+    parser.add_argument(
+        "-i",
+        "--interactive",
+        action="store_true",
+        help="Start een interactieve modus die meerdere woorden accepteert.",
+    )
+    args = parser.parse_args(argv)
+
+    def _build(word: str, override: Sequence[str] | None) -> SyllableTree:
+        return build_syllable_tree(word, syllable_hint=override)
+
+    try:
+        if args.interactive:
+            default_hint = parse_syllable_hint(args.syllables) if args.syllables else None
+            pending: list[str] = [args.word] if args.word else []
+            while True:
+                word = pending.pop(0) if pending else input("Woord (leeg om te stoppen): ").strip()
+                if not word:
+                    break
+                tree = _build(word, default_hint)
+                _print_tree(tree, args.json)
+        else:
+            if not args.word:
+                parser.error("geef een woord op of gebruik --interactive")
+            hint = parse_syllable_hint(args.syllables) if args.syllables else None
+            _print_tree(_build(args.word, hint), args.json)
+    except (EOFError, KeyboardInterrupt):
+        return 1
+    return 0
+
+
+def _print_tree(tree: SyllableTree, as_json: bool) -> None:
+    if as_json:
+        print(tree.to_json())
+    else:
+        print(tree.render())
+
+
+def _syllabify_segment(word: str) -> List[str]:
+    lower = word.lower()
+    nuclei = list(_find_vowel_clusters(lower))
+    if not nuclei:
+        return [word]
+    syllables: List[str] = []
+    previous_boundary = 0
+    for index, (start, end) in enumerate(nuclei):
+        if index == len(nuclei) - 1:
+            syllables.append(word[previous_boundary:])
+        else:
+            next_start, _ = nuclei[index + 1]
+            consonant_cluster = word[end:next_start]
+            coda_length = _split_consonant_cluster(consonant_cluster)
+            boundary = end + coda_length
+            syllables.append(word[previous_boundary:boundary])
+            previous_boundary = boundary
+    return [segment for segment in syllables if segment]
+
+
+def _find_vowel_clusters(word: str) -> Iterator[tuple[int, int]]:
+    index = 0
+    while index < len(word):
+        if word[index] in _VOWELS:
+            start = index
+            while index < len(word) and word[index] in _VOWELS:
+                index += 1
+            yield start, index
+        else:
+            index += 1
+
+
+def _split_consonant_cluster(cluster: str) -> int:
+    if not cluster:
+        return 0
+    lower = cluster.lower()
+    length = len(cluster)
+    max_onset = min(3, length)
+    for onset_size in range(max_onset, 0, -1):
+        if lower[-onset_size:] in _ONSET_CLUSTERS:
+            return length - onset_size
+    return max(length - 1, 0)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI helper
+    sys.exit(run_syllable_tree_app())

--- a/tests_syllable/test_syllable_tree.py
+++ b/tests_syllable/test_syllable_tree.py
@@ -1,0 +1,92 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2024.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Tests for the syllable tree helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "qiskit" / "utils" / "syllable_tree.py"
+SPEC = importlib.util.spec_from_file_location("qiskit.utils.syllable_tree", MODULE_PATH)
+syllable_tree = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader  # for type checkers
+sys.modules.setdefault("qiskit.utils.syllable_tree", syllable_tree)
+SPEC.loader.exec_module(syllable_tree)
+
+SyllableTree = syllable_tree.SyllableTree
+build_syllable_tree = syllable_tree.build_syllable_tree
+parse_syllable_hint = syllable_tree.parse_syllable_hint
+run_syllable_tree_app = syllable_tree.run_syllable_tree_app
+split_onset_nucleus_coda = syllable_tree.split_onset_nucleus_coda
+syllabify = syllable_tree.syllabify
+
+
+@pytest.mark.parametrize(
+    "word,expected",
+    [
+        ("lettergreep", ["let", "ter", "greep"]),
+        ("programma", ["pro", "gram", "ma"]),
+        ("boom", ["boom"]),
+        ("variaties", ["va", "ria", "ties"]),
+    ],
+)
+def test_syllabify_examples(word, expected):
+    assert syllabify(word) == expected
+
+
+def test_parse_syllable_hint():
+    assert parse_syllable_hint("let-ter greep") == ["let", "ter", "greep"]
+
+
+def test_split_onset_nucleus_coda():
+    assert split_onset_nucleus_coda("greep") == ("gr", "ee", "p")
+    assert split_onset_nucleus_coda("boom") == ("b", "oo", "m")
+    assert split_onset_nucleus_coda("ssh") == ("ssh", "", "")
+
+
+def test_build_tree_structure():
+    tree = build_syllable_tree("lettergreep")
+    assert tree.word == "lettergreep"
+    syllable_labels = [node.label for node in tree.root.children]
+    assert syllable_labels == ["Syllable 1: let", "Syllable 2: ter", "Syllable 3: greep"]
+    onset = tree.root.children[0].children[0]
+    assert onset.label == "Onset"
+    assert [child.label for child in onset.children] == ["l"]
+    rime = tree.root.children[0].children[1]
+    assert rime.label == "Rime"
+    nucleus, coda = rime.children
+    assert nucleus.label == "Nucleus"
+    assert [child.label for child in nucleus.children] == ["e"]
+    assert coda.label == "Coda"
+    assert [child.label for child in coda.children] == ["t"]
+
+
+def test_tree_render_and_json():
+    tree = SyllableTree.from_word("programma")
+    rendered = tree.render()
+    assert "Syllable 1: pro" in rendered
+    payload = json.loads(tree.to_json())
+    assert payload["word"] == "programma"
+    assert payload["syllables"] == ["pro", "gram", "ma"]
+
+
+def test_cli_returns_error_on_interrupt(monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda _: (_ for _ in ()).throw(EOFError()))
+    exit_code = run_syllable_tree_app(["--interactive"])
+    assert exit_code == 1


### PR DESCRIPTION
## Summary
- add a standalone `qiskit.utils.syllable_tree` helper with ASCII/JSON rendering and a CLI entry point
- expose the new helper through `qiskit.utils`'s public exports
- cover the syllable builder with targeted unit tests

## Testing
- python -m pytest tests_syllable/test_syllable_tree.py

------
https://chatgpt.com/codex/tasks/task_e_68cd1801b928833196dbee27236ddd00

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a syllable tree helper in qiskit.utils to build and visualize word syllables.
  - Supports optional syllable hints, ASCII rendering, and JSON output.
  - Added a command-line interface with interactive and non-interactive modes.
  - Exposes utilities for syllabification and onset/nucleus/coda splitting.

- Documentation
  - Added a “Syllable tree helper” section covering the new class and utilities.

- Tests
  - Added comprehensive tests for syllabification, hint parsing, component splitting, tree construction, rendering/JSON, and CLI interrupt handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->